### PR TITLE
Update to skema-rs part of docker compose

### DIFF
--- a/end-to-end-rest/docker-compose.yml
+++ b/end-to-end-rest/docker-compose.yml
@@ -1,9 +1,9 @@
 # Docker Compose file for skema services
 version: "3.9"
-      
+
 services:
 
-  mit-tr: 
+  mit-tr:
     image: chunwei/mitaskem-api:latest
     ports:
       - "9010:8000"
@@ -16,7 +16,6 @@ services:
       secret: 8c2fb5a58ae8d9ec6f7065a25c35aac2
       SKEMA_HOSTNAME: skema.clulab.org
       _JAVA_OPTIONS: -Xmx20g -Xms20g -Dfile.encoding=UTF-8
-
 
   jupyter:
     image: lumai/askem-skema-py:latest
@@ -34,16 +33,24 @@ services:
     ports:
       - "8000:8000" # Change port mapping appropriately before deploying.
     # open browser to http://localhost:8000/docs
-    environment: 
+    environment:
       - "SKEMA_RS_ADDESS=skema-rs:8080"
       - "SKEMA_MATHJAX_ADDRESS=http://mathjax:8031"
-      
-    command: ["uvicorn", "skema.rest.api:app", "--host", "0.0.0.0", "--port", "8000"]
+
+    command:
+      [
+        "uvicorn",
+        "skema.rest.api:app",
+        "--host",
+        "0.0.0.0",
+        "--port",
+        "8000"
+      ]
 
   skema-rs:
     image: lumai/askem-skema-rs:latest
     container_name: skema-rs
-    entrypoint: cargo run --release --bin skema_service -- --host 0.0.0.0 --port 8080 --db-host graphdb
+    entrypoint: ./target/release/skema_service --host 0.0.0.0 --port 8080 --db-host graphdb
     ports:
       - "8080:8080"
 
@@ -60,9 +67,8 @@ services:
       - mg_etc:/etc/memgraph
     environment:
       - MEMGRAPH="--log-level=TRACE"
-    entrypoint: ["/usr/bin/supervisord"]
+    entrypoint: [ "/usr/bin/supervisord" ]
 
-  
   # example cmd: curl -X POST http://0.0.0.0:8031/tex2mml \
   # -H "Content-Type: application/json" \
   # -d '{"tex_src": "E = mc^{2}"}'
@@ -76,7 +82,7 @@ services:
     ports:
       - "8031:8031"
     working_dir: /app/skema/img2mml/data_generation
-    entrypoint: ["npm", "start"]
+    entrypoint: [ "npm", "start" ]
 
 volumes:
   mg_lib:


### PR DESCRIPTION
This should make it so that the docker compose only runs the executable instead of compiling and running it. 

I tested with a local image and compose for skema-rs and it worked, so assuming the directory structure looks okay I think it should work. 