### PR TITLE
Memgraph memory limit

### DIFF
--- a/end-to-end-rest/docker-compose.yml
+++ b/end-to-end-rest/docker-compose.yml
@@ -60,7 +60,6 @@ services:
       - mg_etc:/etc/memgraph
     environment:
       - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
-    entrypoint: [ "/usr/bin/supervisord" ]
 
   # example cmd: curl -X POST http://0.0.0.0:8031/tex2mml \
   # -H "Content-Type: application/json" \

--- a/end-to-end-rest/docker-compose.yml
+++ b/end-to-end-rest/docker-compose.yml
@@ -59,7 +59,7 @@ services:
       - mg_log:/var/log/memgraph
       - mg_etc:/etc/memgraph
     environment:
-      - MEMGRAPH="--log-level=TRACE"
+      - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
     entrypoint: [ "/usr/bin/supervisord" ]
 
   # example cmd: curl -X POST http://0.0.0.0:8031/tex2mml \

--- a/morae-demo/docker-compose.memgraph.yml
+++ b/morae-demo/docker-compose.memgraph.yml
@@ -13,7 +13,6 @@ services:
       - mg_etc:/etc/memgraph
     environment:
       - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
-    entrypoint: ["/usr/bin/supervisord"]
 
 volumes:
   mg_lib:

--- a/morae-demo/docker-compose.memgraph.yml
+++ b/morae-demo/docker-compose.memgraph.yml
@@ -12,7 +12,7 @@ services:
       - mg_log:/var/log/memgraph
       - mg_etc:/etc/memgraph
     environment:
-      - MEMGRAPH="--log-level=TRACE"
+      - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
     entrypoint: ["/usr/bin/supervisord"]
 
 volumes:

--- a/morae-demo/docker-compose.skema-rs.yml
+++ b/morae-demo/docker-compose.skema-rs.yml
@@ -23,7 +23,6 @@ services:
       - mg_etc:/etc/memgraph
     environment:
       - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
-    entrypoint: ["/usr/bin/supervisord"]
 
 volumes:
   mg_lib:

--- a/morae-demo/docker-compose.skema-rs.yml
+++ b/morae-demo/docker-compose.skema-rs.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.skema-rs
-    entrypoint: cargo run --release --bin skema_service -- --host 0.0.0.0 --db-host database
+    entrypoint: ./target/release/skema_service --host 0.0.0.0 --port 8080 --db-host database
     ports:
       - "8080:8080"
 

--- a/morae-demo/docker-compose.skema-rs.yml
+++ b/morae-demo/docker-compose.skema-rs.yml
@@ -22,7 +22,7 @@ services:
       - mg_log:/var/log/memgraph
       - mg_etc:/etc/memgraph
     environment:
-      - MEMGRAPH="--log-level=TRACE"
+      - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
     entrypoint: ["/usr/bin/supervisord"]
 
 volumes:

--- a/morae-demo/docker-compose.yml
+++ b/morae-demo/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - mg_log:/var/log/memgraph
       - mg_etc:/etc/memgraph
     environment:
-      - MEMGRAPH="--log-level=TRACE"
+      - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
     entrypoint: ["/usr/bin/supervisord"]
 
 volumes:

--- a/morae-demo/docker-compose.yml
+++ b/morae-demo/docker-compose.yml
@@ -38,7 +38,6 @@ services:
       - mg_etc:/etc/memgraph
     environment:
       - MEMGRAPH=--memory-limit=3000 --log-level=TRACE"
-    entrypoint: ["/usr/bin/supervisord"]
 
 volumes:
   mg_lib:


### PR DESCRIPTION
Updates the memgraph service to remove entrypoint and set memory limit to 3000 for the following files:

- end-to-end-rest/docker-compose.yml
- morae-demo/docker-compose.memgraph.yml
- morae-demo/docker-compose.skema-rs.yml
- morae-demo/docker-compose.yml
